### PR TITLE
use parseCellGroups in plotClusterBarplots

### DIFF
--- a/R/conos.R
+++ b/R/conos.R
@@ -1200,7 +1200,7 @@ findSubcommunities <- function(con, target.clusters, clustering=NULL, groups=NUL
   return(groups.raw)
 }
 
-parseCellGroups <- function(con, clustering, groups, parse.clusters=T) {
+parseCellGroups <- function(con, clustering, groups, parse.clusters=TRUE) {
   if (!parse.clusters)
     return(groups)
 

--- a/R/plot.R
+++ b/R/plot.R
@@ -141,17 +141,20 @@ plotSamples <- function(samples, groups=NULL, colors=NULL, gene=NULL, embedding.
 #' @export
 plotClusterBarplots <- function(conos.obj=NULL, clustering=NULL, groups=NULL,sample.factor=NULL,show.entropy=TRUE,show.size=TRUE,show.composition=TRUE,legend.height=0.2) {
   ## param checking
-  if(!is.null(clustering)) {
-    if(is.null(conos.obj)) stop('conos.obj must be passed if clustering name is specified');
-    if(!clustering %in% names(conos.obj$clusters)) stop('specified clustering doesn\'t exist')
-    groups <- conos.obj$clusters[[clustering]]$groups
-  } else if (is.null(groups)) {
-    if(is.null(conos.obj)) stop('either groups factor on the cells or a conos object needs to be specified')
-    if(is.null(conos.obj$clusters[[1]])) stop('conos object lacks any clustering. run $findCommunities() first')
-    groups <- conos.obj$clusters[[1]]$groups
+  if (!is.null(clustering) && is.null(conos.obj)) {
+    stop('conos.obj must be passed if clustering name is specified')
   }
 
-  groups <- as.factor(groups)
+  if (is.null(groups) && is.null(conos.obj))) {
+    stop('Either groups factor on the cells or a conos object needs to be specified, both cannot be NULL')
+  }
+
+  groups <- parseCellGroups(conos.obj, clustering, groups)
+
+  if (!is.null(groups)) {
+    groups <- as.factor(groups)
+  }
+
   if(is.null(sample.factor)) {
     sample.factor <- conos.obj$getDatasetPerCell(); # assignment to samples
   }


### PR DESCRIPTION
I think this largely addresses: https://github.com/hms-dbmi/conos/issues/48

Naturally, as I go through this a bit, the checks could be made more uniform, and possibly use other functions to do so. 

But in terms of addressing that issue, I think this does it. 

Relevant discussion: https://github.com/hms-dbmi/conos/pull/45/files/2594135923fd991ce3a5526894a6a90b73612aed
Relevant code: https://github.com/hms-dbmi/conos/commit/fabac38f6d16965583f7607e01cfcb3c0e19a74d#diff-40e3c57f569ce5d5d5d694ad32ada4ed