### PR TITLE
Add parmeter `raster.dpi` in `con$plotEmbedding()` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 ## Upcoming
 
-* vignettes edits, detailing p2app4conos() for rendering Conos to pagoda2 application
+### Changed
+
+* vignettes edits, detailing `p2app4conos()` for rendering Conos to pagoda2 application
+
+### Added 
+
+* parameters `dpi` and `dev` in `con$plotEmbedding()` to replace `raster.height` and `raster.width`, given these parameters are defunct with rewrite of `ggrastr` (v0.2.0)[https://github.com/VPetukhov/ggrastr/releases/tag/v0.2.0]
+
+### Removed
+
 
 ## [1.3.1] - 2020-24-09
 
@@ -10,7 +19,6 @@
 - Fixed bug with `balancing.factor.per.sample` in `buildGraph`
 - Fixed some installation problems
 - Improve R6 documentation
-
 
 ### Added
 
@@ -26,6 +34,7 @@
 
 - Removed `getCorrectionVector()` and `getPerCellTypeDECorrected` (2 July 2020)
 - Removed all neighborhood averaging via `neighborhood.average` (4 July 2020)
+- Removed `raster.height` and `raster.width` from `con$plotEmbedding()`, given these parameters are defunct with rewrite of `ggrastr` (v0.2.0)[https://github.com/VPetukhov/ggrastr/releases/tag/v0.2.0]
 
 ## [1.3.0] - 2020-19-3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Added 
 
-* parameters `dpi` and `dev` in `con$plotEmbedding()` to replace `raster.height` and `raster.width`, given these parameters are defunct with rewrite of `ggrastr` (v0.2.0)[https://github.com/VPetukhov/ggrastr/releases/tag/v0.2.0]
+* add parameter `raster.dpi` in `con$plotEmbedding()` to replace `raster.height` and `raster.width`, given these parameters are defunct with rewrite of `ggrastr` (v0.2.0)[https://github.com/VPetukhov/ggrastr/releases/tag/v0.2.0]
 
 ### Removed
 

--- a/R/plot.R
+++ b/R/plot.R
@@ -39,7 +39,7 @@ getClusteringGroups <- function(clusters, clustering) {
 #' @param subset a subset of cells to show (vector of cell names)
 #' @param return.plotlist return a list of ggplot objects instead of a combined plot (default=FALSE)
 #' @return ggplot2 object with the panel of plots
-plotEmbeddings <- function(embeddings, groups=NULL, colors=NULL, ncol=NULL, nrow=NULL, raster=FALSE, panel.size=NULL, adjust.func=NULL, title.size=6, adj.list=NULL, subset=NULL, return.plotlist=FALSE, ...) {
+plotEmbeddings <- function(embeddings, groups=NULL, colors=NULL, ncol=NULL, nrow=NULL, raster=FALSE, raster.dpi=300, panel.size=NULL, adjust.func=NULL, title.size=6, adj.list=NULL, subset=NULL, return.plotlist=FALSE, ...) {
   if (is.null(panel.size)) {
     panel.size <- dev.size(units="in")
   } else if (length(panel.size) == 1) {
@@ -66,7 +66,7 @@ plotEmbeddings <- function(embeddings, groups=NULL, colors=NULL, ncol=NULL, nrow
     if(!is.null(subset)) {
       emb <- emb[rownames(emb) %in% subset,,drop=FALSE]
     }
-    embeddingPlot(emb, groups=groups, colors=colors, raster=raster, ...) +
+    embeddingPlot(emb, groups=groups, colors=colors, raster=raster, raster.dpi=raster.dpi, ...) +
       ggplot2::geom_label(data=data.frame(x=-Inf, y=Inf, label=n), mapping=ggplot2::aes(x=x, y=y, label=label),
                           fill=ggplot2::alpha("white", 0.6), hjust=0, vjust=1, size=title.size,
                           label.padding=ggplot2::unit(title.size / 4, "pt"), label.size = NA)

--- a/man/plotComponentVariance.Rd
+++ b/man/plotComponentVariance.Rd
@@ -4,7 +4,11 @@
 \alias{plotComponentVariance}
 \title{Plot variance explained by the successive components}
 \usage{
-plotComponentVariance(conos.obj, space = "PCA", plot.theme = theme_bw())
+plotComponentVariance(
+  conos.obj,
+  space = "PCA",
+  plot.theme = ggplot2::theme_bw()
+)
 }
 \arguments{
 \item{conos.obj}{conos object}

--- a/man/plotEmbeddings.Rd
+++ b/man/plotEmbeddings.Rd
@@ -11,6 +11,7 @@ plotEmbeddings(
   ncol = NULL,
   nrow = NULL,
   raster = FALSE,
+  raster.dpi = 300,
   panel.size = NULL,
   adjust.func = NULL,
   title.size = 6,
@@ -32,6 +33,8 @@ plotEmbeddings(
 \item{nrow}{number of rows in the panel}
 
 \item{raster}{boolean whether layer with the points be rasterized (default=FALSE). Setting of this argument to TRUE is useful when you need to export a plot with large number of points}
+
+\item{raster.dpi}{dpi of the rasterized plot. (default=300). Ignored if raster == FALSE.}
 
 \item{panel.size}{vector with two numbers, which specified (width, height) of the panel in inches. Ignored if raster == FALSE.}
 


### PR DESCRIPTION
Add parameter `raster.dpi` in `con$plotEmbedding()` to replace `raster.height` and `raster.width`, given these parameters are defunct with rewrite of `ggrastr` (v0.2.0)[https://github.com/VPetukhov/ggrastr/releases/tag/v0.2.0]