### PR TITLE
add fixes for updatePairs, and Seurat variance scaling

### DIFF
--- a/R/conclass.R
+++ b/R/conclass.R
@@ -1078,7 +1078,7 @@ Conos <- R6::R6Class("Conos", lock_objects=FALSE,
           }
           if(verbose) cat(".")
           xcp
-        }, n.cores=self$n.cores, mc.preschedule=(space=='PCA'), progress=verbose)
+        }, n.cores=self$n.cores, mc.preschedule=(space=='PCA'), progress=FALSE)
 
         names(xl2) <- apply(sn.pairs[,which(is.na(mi)),drop=FALSE],2,paste,collapse='.vs.')
         xl2 <- xl2[!unlist(lapply(xl2,is.null))]

--- a/R/conos.R
+++ b/R/conos.R
@@ -117,8 +117,8 @@ commonOverdispersedGenes <- function(samples, n.odgenes, verbose) {
 }
 
 #' @keywords internal
-quickNULL <- function(p2.objs, data.type='counts', n.odgenes = NULL, var.scale = T,
-                      verbose = TRUE) {
+quickNULL <- function(p2.objs, data.type='counts', n.odgenes = NULL, var.scale = TRUE, verbose = TRUE) {
+  
   if (length(p2.objs) != 2){
     stop('quickNULL only supports pairwise alignment')
   }

--- a/R/conos.R
+++ b/R/conos.R
@@ -48,7 +48,7 @@ scaledMatricesP2 <- function(p2.objs, data.type, od.genes, var.scale) {
 #' @keywords internal
 scaledMatricesSeurat <- function(so.objs, data.type, od.genes, var.scale) {
   if (var.scale) {
-    warning("Seurat doesn't support variance scaling")
+    so.objs <- lapply(so.objs, function(so){ ScaleData(so, features = rownames(so))})
   }
 
   if (data.type == 'scaled') {
@@ -67,7 +67,7 @@ scaledMatricesSeurat <- function(so.objs, data.type, od.genes, var.scale) {
 scaledMatricesSeuratV3 <- function(so.objs, data.type, od.genes, var.scale, neighborhood.average) {
   checkSeuratV3()
   if (var.scale) {
-    warning("Seurat doesn't support variance scaling")
+    so.objs <- lapply(so.objs, function(so){ ScaleData(so, features = rownames(so))})
   }
   slot <- switch(
     EXPR = data.type,


### PR DESCRIPTION
Related to this issue: https://github.com/kharchenkolab/conos/issues/101

There are two fixes here: 
(1) I noticed that `sccore::plapply()` would give different results here: https://github.com/kharchenkolab/conos/blob/master/R/conclass.R#L1067-L1081

It looks like `pbmcapply::pbmclapply()` would result in a list with two elements, `$value` and `$warning`. Somehow, the warning output `Seurat doesn't support variance scaling` would become an element to the list....that was the fundamental error that the OP of the Issue #101 noticed. 

(2) Seurat has variance scaling now: https://satijalab.org/seurat/archive/v3.0/pbmc3k_tutorial.html
So I removed the warning, and applied this function.


If the PR is accepted, I'll update the CHANGELOG.

Background:

This code worked: 

```
library(Seurat)
suppressWarnings(library(SeuratData))
library(SeuratWrappers)
library(dplyr)
library(conos)
data("ifnb")

ifnb.panel <- SplitObject(ifnb, split.by = "stim")
for (i in 1:length(ifnb.panel)) {
  ifnb.panel[[i]] <- NormalizeData(ifnb.panel[[i]]) %>% FindVariableFeatures() %>% ScaleData() %>% 
    RunPCA(verbose = FALSE)
}

ifnb.con <- Conos$new(ifnb.panel)
ifnb.con$buildGraph(k = 15, k.self = 5, space = "PCA", ncomps = 30, n.odgenes = 2000, matching.method = "mNN", 
                    metric = "angular", score.component.variance = TRUE, verbose = TRUE)
```

This did not:
```
library(Seurat)
library(SeuratData)
library(conos)
LoadData("ifnb")

# split the dataset into a list of two seurat objects (stim and CTRL)
ifnb.list <- SplitObject(ifnb, split.by = "stim")

for (i in 1:length(ifnb.list)) {
    ifnb.list[[i]] <- NormalizeData(ifnb.list[[i]]) %>% FindVariableFeatures() %>% ScaleData() %>% RunPCA(verbose = FALSE)
}

con <- Conos$new(ifnb.list , n.cores=4)
con$buildGraph(k=15, k.self=5, space="PCA", ncomps=30, n.odgenes=2000, matching.method="mNN", metric="angular", 
      score.component.variance=TRUE, verbose=TRUE)
```