### PR TITLE
Fix parseCellGroups() to check if clustering exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Upcoming
 
+## [1.4.3] - 2021-02-08
+
+### Changed
+- Fix the function `parseCellGroups()`, check if clustering exists
+
+
 ## [1.4.2] - 2021-28-06
 
 ### Changed

--- a/R/conos.R
+++ b/R/conos.R
@@ -1152,6 +1152,7 @@ findSubcommunities <- function(con, target.clusters, clustering=NULL, groups=NUL
 
 #' @keywords internal
 parseCellGroups <- function(con, clustering, groups, parse.clusters=TRUE) {
+
   if (!parse.clusters){
     return(groups)
   }
@@ -1163,14 +1164,17 @@ parseCellGroups <- function(con, clustering, groups, parse.clusters=TRUE) {
     return(groups)
   }
 
+  if (length(con$clusters) < 1){
+    stop("Generate a joint clustering first")
+  } else if (!(clustering %in% names(con$clusters)) && !is.null(clustering)) {
+    stop(paste("Clustering",clustering,"does not exist, run findCommunity() first"))
+  }
+
   if (is.null(clustering)) {
     if (length(con$clusters) > 0){
       return(con$clusters[[1]]$groups)
     }
     stop("Either 'groups' must be provided or the conos object must have some clustering estimated")
-  }
-  if (is.null(clusters[[clustering]])){
-    stop(paste("Clustering",clustering,"doesn't exist, run findCommunity() first"))
   }
 
   return(con$clusters[[clustering]]$groups)


### PR DESCRIPTION
Motivated by the following issue: https://github.com/kharchenkolab/conos/issues/105

It looks like there's a flaw in the logic of `parseCellGroups()`, which resulted in an error thrown, e.g. 

```
> con$plotPanel(font.size=4)
> con$plotPanel(font.size=4, clustering="multilevel")
Error in getClusteringGroups(self$clusters, clustering) : 
  clustering multilevel hasn't been calculated
```
  
These changes fix this behavior by checking if the `clustering` given exists. If not, throw an informative error. 

Following the walkthrough
https://github.com/kharchenkolab/conos/blob/master/doc/walkthrough.md

```
> plotComponentVariance(con, space='PCA')
> con$plotPanel(clustering="multilevel", use.local.clusters=TRUE, title.size=6)
> con$findCommunities(method=leiden.community, resolution=1)
> con$plotPanel(font.size=4)
> plotClusterBarplots(con, legend.height = 0.1)
> plotClusterBarplots(con, legend.height = 0.1, clustering="leiden")
> plotClusterBarplots(con, legend.height = 0.1, clustering="walktrap")
Error in parseCellGroups(conos.obj, clustering, groups) : 
  Clustering walktrap does not exist, run findCommunity() first
```

This behavior is expected, as `"walktrap"` clustering was never performed. 

  