### PR TITLE
Allow embedding parameter to be case insensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 - Fix the function `parseCellGroups()`, check if clustering exists
-
+- Allow 'embedding' parameter to be case insensitive in the Conos methods 'embedGraph()', 'getEmbedding()', 'plotGraph()', and 'plotPanel()'.
 
 ## [1.4.2] - 2021-28-06
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: conos
 Title: Clustering on Network of Samples
-Version: 1.4.2
+Version: 1.4.3
 Authors@R: c(person("Viktor","Petukhov", email="viktor.s.petuhov@ya.ru", role="aut"), person("Nikolas","Barkas", email="nikolas_barkas@hms.harvard.edu", role="aut"), person("Peter", "Kharchenko", email = "peter_kharchenko@hms.harvard.edu", role = "aut"), person("Weiliang", "Qiu", email = "weiliang.qiu@gmail.com", role = c("ctb")), person("Evan", "Biederstedt", email="evan.biederstedt@gmail.com", role=c("aut", "cre")))
 Description: Wires together large collections of single-cell RNA-seq datasets, which allows for both the identification of recurrent cell clusters and the propagation of information between datasets in multi-sample or atlas-scale collections. 'Conos' focuses on the uniform mapping of homologous cell types across heterogeneous sample collections. For instance, users could investigate a collection of dozens of peripheral blood samples from cancer patients combined with dozens of controls, which perhaps includes samples of a related tissue such as lymph nodes. This package interacts with data available through the 'conosPanel' package, which is available in a 'drat' repository. To access this data package, see the instructions at <https://github.com/kharchenkolab/conos>. The size of the 'conosPanel' package is approximately 12 MB.
 License: GPL-3

--- a/R/conclass.R
+++ b/R/conclass.R
@@ -623,7 +623,7 @@ Conos <- R6::R6Class("Conos", lock_objects=FALSE,
     plotPanel=function(clustering=NULL, groups=NULL, colors=NULL, gene=NULL, use.local.clusters=FALSE, plot.theme=NULL, use.common.embedding=FALSE, embedding=NULL, adj.list=NULL, ...) {
 
       ## allow inputs to be not case sensitive
-      if (!is.null(embedding)){
+      if (class(embedding)=='character' && !is.null(embedding)){
         embedding = tolower(embedding)
       }
 
@@ -673,7 +673,7 @@ Conos <- R6::R6Class("Conos", lock_objects=FALSE,
 
       ## inputs no longer case sensitive
       '%ni%' <- Negate('%in%')
-      if (tolower(method) %ni% tolower(supported.methods)) {
+      if (class(embedding)=='character' && tolower(method) %ni% tolower(supported.methods)) {
         stop(paste0("Currently, only the following embeddings are supported: ",paste(supported.methods,collapse=' ')))
       }
 
@@ -823,7 +823,7 @@ Conos <- R6::R6Class("Conos", lock_objects=FALSE,
     plotGraph=function(color.by='cluster', clustering=NULL, embedding=NULL, groups=NULL, colors=NULL, gene=NULL, plot.theme=NULL, subset=NULL, ...) {
 
       ## allow inputs to be not case sensitive
-      if (!is.null(embedding)){
+      if (class(embedding)=='character' && !is.null(embedding)){
         embedding = tolower(embedding)
       }
       
@@ -1016,6 +1016,8 @@ Conos <- R6::R6Class("Conos", lock_objects=FALSE,
         if(class(embedding) %in% c('matrix')) { # actuall embedding was passed
           # check validity?
         } else if(class(embedding)=='character') {  # look up embedding by name
+          ## allow inputs to be not case sensitive
+          embedding = tolower(embedding)
           ## check if embedding.name exists in list
           if (embedding %in% names(self$embeddings)) {
             ## embedding to plot

--- a/R/conclass.R
+++ b/R/conclass.R
@@ -622,6 +622,11 @@ Conos <- R6::R6Class("Conos", lock_objects=FALSE,
     #'
     plotPanel=function(clustering=NULL, groups=NULL, colors=NULL, gene=NULL, use.local.clusters=FALSE, plot.theme=NULL, use.common.embedding=FALSE, embedding=NULL, adj.list=NULL, ...) {
 
+      ## allow inputs to be not case sensitive
+      if (!is.null(embedding)){
+        embedding = tolower(embedding)
+      }
+
       if (use.local.clusters) {
         if (is.null(clustering) && !(inherits(x = self$samples[[1]], what = c('seurat', 'Seurat')))) {
           stop("You have to provide 'clustering' parameter to be able to use local clusters")
@@ -665,7 +670,10 @@ Conos <- R6::R6Class("Conos", lock_objects=FALSE,
     #'
     embedGraph=function(method='largeVis', embedding.name=method, M=1, gamma=1, alpha=0.1, perplexity=NA, sgd_batches=1e8, seed=1, verbose=TRUE, target.dims=2, ...) {
       supported.methods <- c('largeVis', 'UMAP')
-      if(!method %in% supported.methods) {
+
+      ## inputs no longer case sensitive
+      '%ni%' <- Negate('%in%')
+      if (tolower(method) %ni% tolower(supported.methods)) {
         stop(paste0("Currently, only the following embeddings are supported: ",paste(supported.methods,collapse=' ')))
       }
 
@@ -813,6 +821,12 @@ Conos <- R6::R6Class("Conos", lock_objects=FALSE,
     #' @return ggplot2 plot of joint graph
     #'
     plotGraph=function(color.by='cluster', clustering=NULL, embedding=NULL, groups=NULL, colors=NULL, gene=NULL, plot.theme=NULL, subset=NULL, ...) {
+
+      ## allow inputs to be not case sensitive
+      if (!is.null(embedding)){
+        embedding = tolower(embedding)
+      }
+      
       embedding <- private$getEmbedding(embedding)
 
       if (!is.null(subset)) {

--- a/R/conclass.R
+++ b/R/conclass.R
@@ -673,7 +673,7 @@ Conos <- R6::R6Class("Conos", lock_objects=FALSE,
 
       ## inputs no longer case sensitive
       '%ni%' <- Negate('%in%')
-      if (class(embedding)=='character' && tolower(method) %ni% tolower(supported.methods)) {
+      if (class(method)=='character' && tolower(method) %ni% tolower(supported.methods)) {
         stop(paste0("Currently, only the following embeddings are supported: ",paste(supported.methods,collapse=' ')))
       }
 

--- a/R/conclass.R
+++ b/R/conclass.R
@@ -822,11 +822,6 @@ Conos <- R6::R6Class("Conos", lock_objects=FALSE,
     #'
     plotGraph=function(color.by='cluster', clustering=NULL, embedding=NULL, groups=NULL, colors=NULL, gene=NULL, plot.theme=NULL, subset=NULL, ...) {
 
-      ## allow inputs to be not case sensitive
-      if (class(embedding)=='character' && !is.null(embedding)){
-        embedding = tolower(embedding)
-      }
-      
       embedding <- private$getEmbedding(embedding)
 
       if (!is.null(subset)) {
@@ -1019,9 +1014,13 @@ Conos <- R6::R6Class("Conos", lock_objects=FALSE,
           ## allow inputs to be not case sensitive
           embedding = tolower(embedding)
           ## check if embedding.name exists in list
-          if (embedding %in% names(self$embeddings)) {
+          ## allow inputs to be not case sensitive
+          if (tolower(embedding) %in% tolower(names(self$embeddings))) {
             ## embedding to plot
-            embedding <- self$embeddings[[embedding]]
+            ## Note: allow access of case insenstive names
+            available_embeddings_list <- self$embeddings
+            names(available_embeddings_list) <- tolower(names(available_embeddings_list)) ## all embedding names lowercase
+            embedding <- available_embeddings_list[[tolower(embedding)]] ##embedding <- self$embeddings[[embedding]]
           } else {
             ## embedding.name not in list of self$embeddings, so the user is confused
             ## throw error

--- a/README.md
+++ b/README.md
@@ -238,5 +238,5 @@ The R package can be cited as:
 ```
 Viktor Petukhov, Nikolas Barkas, Peter Kharchenko, and Evan
 Biederstedt (2021). conos: Clustering on Network of Samples. R
-package version 1.4.2.
+package version 1.4.3.
 ```


### PR DESCRIPTION
Related to this issue: https://github.com/kharchenkolab/conos/issues/108

The methods in the Conos class `embedGraph()`, `etEmbedding()`, `plotGraph()` and `plotPanel()` now allow the parameter `embedding` to be case insensitive. 